### PR TITLE
HierarchyRequestError on latest Chrome

### DIFF
--- a/dist/tiny-slider.js
+++ b/dist/tiny-slider.js
@@ -984,7 +984,11 @@ var tns = function(options) {
     rect = div.getBoundingClientRect();
     width = rect.right - rect.left;
     div.remove();
-    return width || getClientWidth(el.parentNode);
+    if (width) {
+      return width;
+    } else if (null !== el.parentNode.parentNode) {
+        return getClientWidth(el.parentNode);
+    }
   }
 
   function getViewportWidth () {

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -545,7 +545,13 @@ export var tns = function(options) {
     rect = div.getBoundingClientRect();
     width = rect.right - rect.left;
     div.remove();
-    return width || getClientWidth(el.parentNode);
+    if (width) {
+        return width;
+    } else if (el.parentNode.parentNode !== null) {
+        getClientWidth(el.parentNode);
+    } else {
+        return;
+    }
   }
 
   function getViewportWidth () {

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -547,10 +547,8 @@ export var tns = function(options) {
     div.remove();
     if (width) {
         return width;
-    } else if (el.parentNode.parentNode !== null) {
-        getClientWidth(el.parentNode);
-    } else {
-        return;
+    } else if (null !== el.parentNode.parentNode) {
+        return getClientWidth(el.parentNode);
     }
   }
 


### PR DESCRIPTION
Error
```
HierarchyRequestError: Failed to execute 'appendChild' on 'Node': Only one element on document allowed.
```

See: https://github.com/ganlanyuan/tiny-slider/pull/614